### PR TITLE
Fix order of lat/lon in wildfire use case

### DIFF
--- a/WorkflowManager/workflows/wildfire/hotspots.py
+++ b/WorkflowManager/workflows/wildfire/hotspots.py
@@ -268,8 +268,8 @@ def wildfire_process_hotspots(msg):
             upperLeft = i.upper_left_latlong
             lowerRight = i.lower_right_latlong
             
-            lonmin, latmax = upperLeft.split("/")
-            lonmax, latmin = lowerRight.split("/")
+            latmax, lonmin = upperLeft.split("/")
+            latmin, lonmax = lowerRight.split("/")
 
             lonmin = float(lonmin)
             latmax = float(latmax)

--- a/WorkflowManager/workflows/wildfire/main.py
+++ b/WorkflowManager/workflows/wildfire/main.py
@@ -23,8 +23,8 @@ def wildfire_init(msg):
             raise Exception("Location extents must be of the form longitude/latitude")
 
         try:
-            upperLeftLon, upperLeftLat = upperLeft.split("/")
-            lowerRightLon, lowerRightLat = lowerRight.split("/")
+            upperLeftLat, upperLeftLon = upperLeft.split("/")
+            lowerRightLat, lowerRightLon = lowerRight.split("/")
     
             float(upperLeftLat)
             float(upperLeftLon)

--- a/WorkflowManager/workflows/wildfire/mesoNH.py
+++ b/WorkflowManager/workflows/wildfire/mesoNH.py
@@ -126,8 +126,8 @@ def wildfire_mesonh_physiographic(msg):
     upperLeft = i.upper_left_latlong
     lowerRight = i.lower_right_latlong
             
-    upperLeftLon, upperLeftLat = upperLeft.split("/")
-    lowerRightLon, lowerRightLat = lowerRight.split("/")
+    upperLeftLat, upperLeftLon = upperLeft.split("/")
+    lowerRightLat, lowerRightLon = lowerRight.split("/")
 
     sample_configuration_file = open("workflows/wildfire/templates/prep_pgd.yml")
     yaml_template = yaml.load(sample_configuration_file, Loader=yaml.FullLoader)
@@ -280,8 +280,8 @@ def _buildMesoNHYaml(incidentId, machine_basedir, simulation_location, gfs_file1
     upperLeft = myincident.upper_left_latlong
     lowerRight = myincident.lower_right_latlong
             
-    upperLeftLon, upperLeftLat = upperLeft.split("/")
-    lowerRightLon, lowerRightLat = lowerRight.split("/")
+    upperLeftLat, upperLeftLon = upperLeft.split("/")
+    lowerRightLat, lowerRightLon = lowerRight.split("/")
 
     sample_configuration_file = open("workflows/wildfire/templates/mesonh.yml")
     yaml_template = yaml.load(sample_configuration_file, Loader=yaml.FullLoader)    

--- a/WorkflowManager/workflows/wildfire/wildfire.py
+++ b/WorkflowManager/workflows/wildfire/wildfire.py
@@ -92,8 +92,8 @@ def _buildWFAYaml(incidentId, weather_datainfo):
     lowerRight = myincident.lower_right_latlong
     duration = myincident.duration
             
-    upperLeftLon, upperLeftLat = upperLeft.split("/")
-    lowerRightLon, lowerRightLat = lowerRight.split("/")
+    upperLeftLat, upperLeftLon = upperLeft.split("/")
+    lowerRightLat, lowerRightLon = lowerRight.split("/")
 
     sample_configuration_file = open("workflows/wildfire/templates/wfa.yml")
     yaml_template = yaml.load(sample_configuration_file, Loader=yaml.FullLoader)    


### PR DESCRIPTION
The latitude and longitude coordinates were read in the
wrong order.
The VESTEC interface asks for "lat/lon" which is internally
stored into upperLeft and lowerRight variables.
These were then wrongly split into individual coords by
lon, lat = upperLeft.split("/")

We corrected this to
lat, lon = upperLeft.split("/")

Also, the min/max coordinates for the hotspot points
were in the wrong order
upperLeft gives latmax and lonmin
lowerRight gives latmin and lonmax